### PR TITLE
Boundaries controller testing

### DIFF
--- a/app/controllers/boundaries_controller.rb
+++ b/app/controllers/boundaries_controller.rb
@@ -10,7 +10,7 @@ class BoundariesController < ApplicationController
     def boundary
         new_boundary = Boundary.make(request.body.read)
         if new_boundary == "boundary by this name already exists"
-            render json: {error: "boundary by this name already exists"}, status: :conflict
+            render json: {error: new_boundary}, status: :conflict
             return
         end
         render json: {boundary: new_boundary}, status: :ok
@@ -18,14 +18,18 @@ class BoundariesController < ApplicationController
     def get_boundary
         boundary = Boundary.find_by_name(params[:name])
         if !boundary
-            render json: {error:"no boundary by this name"}, status: :not_found
+            render json: {error: "no boundary by this name"}, status: :not_found
             return
         end
         render json: {boundary: boundary}, status: :ok
     end
     def delete_boundary
-        boundary = Boundary.delete_by_name(params[:name])
-        render json: boundary
+        deleted_boundary = Boundary.delete_by_name(params[:name])
+        if deleted_boundary == "no boundary by this name exists"
+            render json: {error: deleted_boundary}, status: :not_found
+            return
+        end
+        render json: {boundary: deleted_boundary}, status: :ok
     end
     def inside_by_name
         boundary = Boundary.find_by_name(params[:name])

--- a/app/controllers/boundaries_controller.rb
+++ b/app/controllers/boundaries_controller.rb
@@ -8,7 +8,12 @@ class BoundariesController < ApplicationController
         render json: is_inside
     end
     def boundary
-        new_boundary = Boundary.make(request.body.read)
+        begin
+            new_boundary = Boundary.make(request.body.read)
+        rescue Exception
+            render json: {error: "an error occured"}, status: :internal_server_error
+            return
+        end
         if new_boundary == "boundary by this name already exists"
             render json: {error: new_boundary}, status: :conflict
             return

--- a/test/controllers/boundaries_controller_test.rb
+++ b/test/controllers/boundaries_controller_test.rb
@@ -21,6 +21,21 @@ class BoundariesControllerTest < ActionDispatch::IntegrationTest
     post boundary_url, params: bparam, as: :json
     post boundary_url, params: bparam, as: :json
     assert_response :conflict
+    response_json = JSON.parse(response.body)
+    assert response_json.key?('error')
+    error = response_json['error']
+    assert_equal error, "boundary by this name already exists"
+  end
+  test "create invalid boundary (improper format, no name)" do
+    boundary_json = file_fixture("27516.json").read
+    bparam = JSON.parse(boundary_json)
+    improper_param = bparam['geometry']
+    post boundary_url, params: improper_param, as: :json
+    assert_response :internal_server_error
+    response_json = JSON.parse(response.body)
+    assert response_json.key?('error')
+    error = response_json['error']
+    assert_equal error, "an error occured"
   end
   test "get boundary by name" do
     boundary_json = file_fixture("27516.json").read

--- a/test/controllers/boundaries_controller_test.rb
+++ b/test/controllers/boundaries_controller_test.rb
@@ -94,6 +94,18 @@ class BoundariesControllerTest < ActionDispatch::IntegrationTest
     is_inside = response_json['is_inside']
     assert_equal is_inside, true
   end
+  test "point is inside zipcode peninsula" do
+    boundary_json = file_fixture("27516.json").read
+    bparam = JSON.parse(boundary_json)
+    post boundary_url, params: bparam, as: :json
+    #chosen because the horizontal scan leaves and reenters the polygon
+    post "/inside/27516", params: {point: [-79.135343,35.852815]}, as: :json
+    assert_response :success
+    response_json = JSON.parse(response.body)
+    assert response_json.key?('is_inside')
+    is_inside = response_json['is_inside']
+    assert_equal is_inside, true
+  end
   test "point is inside polygon negative" do
     small_rectangle_negative = boundaries(:small_rectangle_negative)
     post "/inside/#{small_rectangle_negative.name}", params: {point: [-1,-1]}, as: :json

--- a/test/controllers/boundaries_controller_test.rb
+++ b/test/controllers/boundaries_controller_test.rb
@@ -41,6 +41,34 @@ class BoundariesControllerTest < ActionDispatch::IntegrationTest
     unreal_name = "this_is_not_a_name"
     get "/boundary/#{unreal_name}"
     assert_response :not_found
+    response_json = JSON.parse(response.body)
+    assert response_json.key?('error')
+    error = response_json['error']
+    assert_equal error, "no boundary by this name"
+  end
+  test "delete boundary by name" do
+    boundary_json = file_fixture("27516.json").read
+    bparam = JSON.parse(boundary_json)
+    post boundary_url, params: bparam, as: :json
+    delete "/boundary/27516"
+    assert_response :success
+    response_json = JSON.parse(response.body)
+    assert response_json.key?('boundary')
+    boundary = response_json['boundary']
+    assert_equal boundary['name'], "27516"
+    assert_equal boundary['minx'], -79.264575
+    assert_equal boundary['maxx'], -79.053125
+    assert_equal boundary['miny'], 35.811339
+    assert_equal boundary['maxy'], 36.017264
+  end
+  test "delete nonexistent boundary" do
+    unreal_name = "this_is_not_a_name"
+    delete "/boundary/#{unreal_name}"
+    assert_response :not_found
+    response_json = JSON.parse(response.body)
+    assert response_json.key?('error')
+    error = response_json['error']
+    assert_equal error, "no boundary by this name exists"
   end
   test "point is inside polygon" do
     small_rectangle_origin = boundaries(:small_rectangle_origin)


### PR DESCRIPTION
Add HTTP response statuses and test routes.

Add HTTP response status for delete route and boundary route.
Enable exception handling for boundary creation.
Test improper boundary creation due to invalid format and no name.
Test delete route.
Test zipcode case inside.
